### PR TITLE
INFL-18366 ci: migrate to GitHub ARC prod runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, production]
+    runs-on: gofireflyio-runner-prod-arc-arm
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3


### PR DESCRIPTION
⚠️ DO NOT MERGE until the prod ARC pools are live — depends on infralight/argocd#3897 being merged + synced + the scale set showing Online. Merging before then makes CI jobs queue forever.

Migrates `runs-on` from the deprecated Summerwind label set to the GitHub ARC scale-set name `gofireflyio-runner-prod-arc-arm` (ARC scale sets route by name, not labels). Part of INFL-18366.