### PR TITLE
INFL-18366: migrate CI runners to GitHub ARC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: [self-hosted, production]
+    runs-on: gofireflyio-runner-prod-arc-arm
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3


### PR DESCRIPTION
release.yml -> gofireflyio-runner-prod-arc-arm (gofireflyio org has only an arm pool).

Migrate CI runners from Summerwind label arrays to GitHub ARC scale sets (INFL-18366). Rules: arch-less labels map to the amd pool (agreed default); explicit arm64 kept; automation role maps to the automation pool; env-templated runs-on stays templated across envs. DRAFT: hold until each target env ARC pool is validated (only stag is live today).

Generated with Claude Code